### PR TITLE
Add support for pickpocket loot

### DIFF
--- a/src/main/java/com/masterkenth/PickpocketRarity.java
+++ b/src/main/java/com/masterkenth/PickpocketRarity.java
@@ -1,0 +1,59 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2020, MasterKenth, thefungus
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.masterkenth;
+
+import lombok.AllArgsConstructor;
+import net.runelite.api.ItemID;
+import com.google.common.collect.ImmutableMap;
+
+// All rarity data have been manually scraped from osrs wiki
+// Data set only contain (subjectively) rare drops so that if a drop matches against a pickpocket it is always posted to Discord
+@AllArgsConstructor
+public enum PickpocketRarity
+{
+    // @formatter:off
+    VYRE_BLOOD_SHARD            (ItemID.BLOOD_SHARD,                    1f / 5000f),
+    ELF_TELEPORT_CRYSTAL        (ItemID.ENHANCED_CRYSTAL_TELEPORT_SEED, 1f / 1024f);
+
+    // @formatter:on
+    private final int itemId;
+    private final float rarity;
+
+    public static final ImmutableMap<Integer, Float> PICKPOCKET_TABLE_MAPPING = initPickpocketMapping();
+
+    private static ImmutableMap<Integer, Float> initPickpocketMapping()
+    {
+        ImmutableMap.Builder<Integer, Float> builder = new ImmutableMap.Builder<>();
+        for (PickpocketRarity r : values())
+        {
+            builder.put(r.itemId, r.rarity);
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/masterkenth/RarityChecker.java
+++ b/src/main/java/com/masterkenth/RarityChecker.java
@@ -87,6 +87,17 @@ public class RarityChecker
     return -1f;
   }
 
+  public float CheckRarityPickpocket(String pickpocketName, int itemId, ItemManager itemManager)
+  {
+    Float rarity = PickpocketRarity.PICKPOCKET_TABLE_MAPPING.getOrDefault(itemId, null);
+    if (rarity != null)
+    {
+      return rarity;
+    }
+
+    return -1f;
+  }
+
   public CompletableFuture<Float> CheckRarityNPC(int npcId, int itemId, ItemManager itemManager)
   {
     CompletableFuture<Float> f = new CompletableFuture<>();


### PR DESCRIPTION
Addresses #8.

Handles pickpockets similarly to how events are currently processed. Only supports blood shard from vyres and the enhanced teleport crystal from elves for now as they're the main rare items obtained from pickpocketing. Further items like the rarer herb seeds from the master farmer could also be added if the demand is there.