### PR TITLE
Change getIconUrl to get s.r.n. URL instead of wiki

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.15'
+def runeLiteVersion = '1.8.32.4'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/masterkenth/ApiTool.java
+++ b/src/main/java/com/masterkenth/ApiTool.java
@@ -66,36 +66,9 @@ public class ApiTool
 	}
 
 
-	public CompletableFuture<String> getIconUrl(String searchType, int searchId, String searchName)
+	public String getIconUrl(int id)
 	{
-		HttpUrl baseUrl = new HttpUrl.Builder().host(WIKI_ROOT).scheme("https").build();
-		HttpUrl url = baseUrl.newBuilder().addPathSegments("w/Special:Lookup").addQueryParameter("type", searchType)
-			.addQueryParameter("id", "" + searchId).addQueryParameter("name", searchName).build();
-
-		Request request = new Request.Builder().url(url).build();
-
-		return callRequest(request).thenCompose(rb ->
-		{
-			CompletableFuture<String> f = new CompletableFuture<>();
-			try
-			{
-				String bodyString = rb.string();
-
-				Document doc = Jsoup.parse(bodyString);
-				Element el = doc.selectFirst("td.inventory-image a.image img");
-				if (el != null)
-				{
-					String srcAttr = el.attributes().get("src");
-					String absoluteIconPath = baseUrl.toString() + srcAttr.substring(1);
-					f.complete(absoluteIconPath);
-				}
-			}
-			catch (Exception e)
-			{
-				f.completeExceptionally(e);
-			}
-			return f;
-		});
+		return String.format("https://static.runelite.net/cache/item/icon/%d.png", id);
 	}
 
 	public CompletableFuture<ResponseBody> postRaw(String url, String data, String type)

--- a/src/main/java/com/masterkenth/DiscordRareDropNotificaterPlugin.java
+++ b/src/main/java/com/masterkenth/DiscordRareDropNotificaterPlugin.java
@@ -493,17 +493,9 @@ public class DiscordRareDropNotificaterPlugin extends Plugin
 		}
 
 		Image thumbnail = new Image();
-		CompletableFuture<Void> iconFuture = ApiTool.getInstance()
-			.getIconUrl("item", itemId, itemManager.getItemComposition(itemId).getName()).handle((iconUrl, e) ->
-			{
-				if (e != null)
-				{
-					log.error(String.format("queueLootNotification (icon %d) error: %s", itemId, e.getMessage()), e);
-				}
-				thumbnail.setUrl(iconUrl);
-				embed.setThumbnail(thumbnail);
-				return null;
-			});
+		String iconUrl = ApiTool.getInstance().getIconUrl(itemId);
+		thumbnail.setUrl(iconUrl);
+		embed.setThumbnail(thumbnail);
 
 		CompletableFuture<Void> descFuture = getLootNotificationDescription(itemId, quantity, npcId, npcCombatLevel,
 			npcName, eventName, !config.sendEmbeddedMessage()).handle((notifDesc, e) ->
@@ -518,7 +510,7 @@ public class DiscordRareDropNotificaterPlugin extends Plugin
 			return null;
 		});
 
-		return CompletableFuture.allOf(descFuture, iconFuture).thenCompose(_v ->
+		return CompletableFuture.allOf(descFuture).thenCompose(_v ->
 		{
 			if(config.sendEmbeddedMessage()) {
 				webhookData.setEmbeds(new Embed[]{embed});

--- a/src/test/java/com/masterkenth/DiscordRareDropNotificaterPluginTest.java
+++ b/src/test/java/com/masterkenth/DiscordRareDropNotificaterPluginTest.java
@@ -7,7 +7,7 @@ public class DiscordRareDropNotificaterPluginTest
 {
 	public static void main(String[] args) throws Exception
 	{
-		//ExternalPluginManager.loadBuiltin(DiscordRareDropNotificaterPlugin.class);
+		ExternalPluginManager.loadBuiltin(DiscordRareDropNotificaterPlugin.class);
 		RuneLite.main(args);
 	}
 }


### PR DESCRIPTION
getIconUrl() used Special:Lookup on the wiki to do some kinda hacky stuff to convert an item ID into an icon url. This is a bit more complicated  and brittle than it needs to be, because RuneLite actually hosts a full set of item icons, indexed by item ID, e.g. https://static.runelite.net/cache/item/icon/9593.png

Screenshot showing it still works with the new icon URLs:

<img width="525" alt="image" src="https://user-images.githubusercontent.com/7573282/188337260-0c5c64b3-b778-4fe5-a35a-f7082d63ea68.png">

I'm making this change because the wiki is going to start blocking okhttp default user-agents to combat overzealous scrapers. This isn't one of them, but it's using the default UA and it seemed like an easy enough opportunity to simplify it all so it doesn't even need to touch the wiki.