### PR TITLE
refactor: utilize more dependency injection

### DIFF
--- a/src/main/java/com/masterkenth/ApiTool.java
+++ b/src/main/java/com/masterkenth/ApiTool.java
@@ -27,11 +27,6 @@
  */
 package com.masterkenth;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
-import net.runelite.client.RuneLite;
-import okhttp3.Cache;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.MediaType;
@@ -42,26 +37,16 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
 public class ApiTool
 {
-	private static ApiTool _instance;
+	@Inject
+	private OkHttpClient httpClient;
 
-	private OkHttpClient httpClient = null;
-
-	public static ApiTool getInstance(OkHttpClient httpClient)
-	{
-		if (_instance == null)
-		{
-			_instance = new ApiTool();
-			_instance.httpClient = httpClient.newBuilder()
-				.cache(new Cache(new File(RuneLite.CACHE_DIR, "okhttp_drdn"), 20 * 1024 * 1024)) // 20mb cache
-				.build();
-		}
-		return _instance;
-	}
-
-
-	public String getIconUrl(int id)
+	public static String getIconUrl(int id)
 	{
 		return String.format("https://static.runelite.net/cache/item/icon/%d.png", id);
 	}

--- a/src/main/java/com/masterkenth/DiscordRareDropNotificaterPlugin.java
+++ b/src/main/java/com/masterkenth/DiscordRareDropNotificaterPlugin.java
@@ -28,7 +28,6 @@
 package com.masterkenth;
 
 import com.google.common.collect.ImmutableList;
-import com.google.gson.Gson;
 import com.google.inject.Provides;
 import com.masterkenth.discord.Author;
 import com.masterkenth.discord.Embed;
@@ -100,12 +99,10 @@ public class DiscordRareDropNotificaterPlugin extends Plugin
 	private DrawManager drawManager;
 
 	@Inject
-	private Gson gson;
-
-	@Inject
 	private OkHttpClient httpClient;
 
-	private final RarityChecker rarityChecker = new RarityChecker(gson);
+	@Inject
+	private RarityChecker rarityChecker;
 
 	private CompletableFuture<java.awt.Image> queuedScreenshot = null;
 
@@ -113,13 +110,6 @@ public class DiscordRareDropNotificaterPlugin extends Plugin
 	DiscordRareDropNotificaterConfig provideConfig(ConfigManager configManager)
 	{
 		return configManager.getConfig(DiscordRareDropNotificaterConfig.class);
-	}
-
-	@Override
-	protected void startUp() throws Exception
-	{
-		JsonUtils.getInstance(gson);
-		super.startUp();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/com/masterkenth/DiscordRareDropNotificaterPlugin.java
+++ b/src/main/java/com/masterkenth/DiscordRareDropNotificaterPlugin.java
@@ -67,7 +67,6 @@ import net.runelite.client.plugins.loottracker.LootReceived;
 import net.runelite.client.ui.DrawManager;
 import net.runelite.http.api.loottracker.LootRecordType;
 import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import org.json.JSONObject;
 
 @Slf4j
@@ -99,7 +98,7 @@ public class DiscordRareDropNotificaterPlugin extends Plugin
 	private DrawManager drawManager;
 
 	@Inject
-	private OkHttpClient httpClient;
+	private ApiTool apiTool;
 
 	@Inject
 	private RarityChecker rarityChecker;
@@ -493,7 +492,7 @@ public class DiscordRareDropNotificaterPlugin extends Plugin
 		}
 
 		Image thumbnail = new Image();
-		String iconUrl = ApiTool.getInstance(httpClient).getIconUrl(itemId);
+		String iconUrl = ApiTool.getIconUrl(itemId);
 		thumbnail.setUrl(iconUrl);
 		embed.setThumbnail(thumbnail);
 
@@ -571,7 +570,7 @@ public class DiscordRareDropNotificaterPlugin extends Plugin
 
 		List<Throwable> exceptions = new ArrayList<>();
 		List<CompletableFuture<Void>> sends = webhookUrls.stream()
-			.map(url -> ApiTool.getInstance(httpClient).postRaw(url, jsonStr, "application/json").handle((_v, e) ->
+			.map(url -> apiTool.postRaw(url, jsonStr, "application/json").handle((_v, e) ->
 			{
 				if (e != null)
 				{
@@ -606,7 +605,7 @@ public class DiscordRareDropNotificaterPlugin extends Plugin
 
 			List<Throwable> exceptions = new ArrayList<>();
 			List<CompletableFuture<Void>> sends = webhookUrls.stream()
-				.map(url -> ApiTool.getInstance(httpClient).postFormImage(url, imageBytes, "image/png").handle((_v, e) ->
+				.map(url -> apiTool.postFormImage(url, imageBytes, "image/png").handle((_v, e) ->
 				{
 					if (e != null)
 					{

--- a/src/main/java/com/masterkenth/JsonUtils.java
+++ b/src/main/java/com/masterkenth/JsonUtils.java
@@ -7,26 +7,19 @@ import java.util.Objects;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.google.gson.stream.JsonReader;
 import com.masterkenth.models.Npc;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 @Slf4j
+@Singleton
 public class JsonUtils
 {
-	private static JsonUtils _instance;
 	private final List<Npc> npcList;
 
-	public static JsonUtils getInstance(Gson gson)
-	{
-		if (_instance == null)
-		{
-			_instance = new JsonUtils(gson);
-		}
-
-		return _instance;
-	}
-
+	@Inject
 	public JsonUtils(Gson gson)
 	{
 		try(InputStreamReader reader = new InputStreamReader(

--- a/src/main/java/com/masterkenth/RarityChecker.java
+++ b/src/main/java/com/masterkenth/RarityChecker.java
@@ -30,24 +30,20 @@ package com.masterkenth;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
-import com.google.gson.Gson;
 import com.masterkenth.models.Npc;
 import com.masterkenth.models.NpcItem;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemComposition;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemVariationMapping;
-import org.json.JSONObject;
+
+import javax.inject.Inject;
 
 @Slf4j
 public class RarityChecker
 {
-	private Gson gson;
-
-	public RarityChecker(Gson gson)
-	{
-		this.gson = gson;
-	}
+	@Inject
+	private JsonUtils jsonUtils;
 
 	public ItemData CheckRarityEvent(String eventName, ItemData item, ItemManager itemManager)
 	{
@@ -138,7 +134,7 @@ public class RarityChecker
 
 		try
 		{
-			Npc npcDrops = JsonUtils.getInstance(this.gson).getNpc(npcName);
+			Npc npcDrops = jsonUtils.getNpc(npcName);
 
 			if(npcDrops != null) {
 				for (Integer id : idVariations)


### PR DESCRIPTION
Previously `RarityChecker` was being initialized with a null gson instance, but this didn't actually cause any problems due to the `JsonUtils.getInstance` call within `startUp`

Regardless, this PR does some code cleanup (but doesn't *need* to be merged)
