### PR TITLE
Update defaults to not notify for rare but low value drops

### DIFF
--- a/src/main/java/com/masterkenth/DiscordRareDropNotificaterConfig.java
+++ b/src/main/java/com/masterkenth/DiscordRareDropNotificaterConfig.java
@@ -108,7 +108,7 @@ public interface DiscordRareDropNotificaterConfig extends Config
 	)
 	default boolean andInsteadOfOr()
 	{
-		return false;
+		return true;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
With the default value of "or" and not "and", this results in notifications like 
> Just got 60x [Fire rune](https://oldschool.runescape.wiki/w/Special:Search?search=Fire%20rune) from lvl 85 [Kalphite Soldier](https://oldschool.runescape.wiki/w/Special:Search?search=Kalphite%20Soldier)
> Rarity # 1/128.0 (0.78125%)
> HA Value120 GP
> GE Value 240 GP

This came up as feedback when clanmates installed the defaults and didn't change the default values.

Perhaps leaning towards sending fewer notifications by default might be a good move and allow players to switch to sending more notifications.